### PR TITLE
fix 'Error with converting to markdown'

### DIFF
--- a/browser/actions.js
+++ b/browser/actions.js
@@ -107,6 +107,7 @@
 		 *                "[left][left][left]"+
 		 *                "[shift-up][delete]")
 		 * @codeend
+		 *
 		 * <h2>Characters</h2>
 		 * 
 		 * For a list of the characters you can type, check [Syn.keycodes].


### PR DESCRIPTION
when building docs (js jmvc\scripts\doc.js)

I's just an extra commet line after @codeend
and I can't tell you why, but at least in my environment doc.js stumbles when it is missing.
