### PR TITLE
Wait commands don't work on numeric contexts

### DIFF
--- a/test/funcunit/funcunit_test.js
+++ b/test/funcunit/funcunit_test.js
@@ -12,7 +12,9 @@ test("qUnit module setup works async", function(){
 })
 
 test("Iframe access", function(){
-	equals(S("h2",0).text(), "Goodbye World", "text of iframe")
+	S("h2",0).exists(function(){
+		equals(S("h2",0).text(), "Goodbye World", "text of iframe");
+	});
 })
 
 test("typing alt and shift characters", function(){


### PR DESCRIPTION
This pull request is for a test that reproduces the problem I am having.

http://javascriptmvc.com/docs.html#!funcunit.finding

That documentation states that S('selector', 0) should be a valid option and I should be able to do S('selector', 0).exists(); However it appears iframe name="" is the only option that will work.
