### PR TITLE
Updates tests to point to new jQuery location

### DIFF
--- a/build.js
+++ b/build.js
@@ -14,7 +14,7 @@ pluginify('funcunit.js', {
 				'funcunit/': '',
 				'src/': 'lib/syn/src/',
 				'syn/': 'lib/syn/src/',
-                "basejquery": "lib/jquery/jquery.js",
+				"basejquery": "lib/jquery/dist/jquery.js",
                 "jquery": "browser/jquery.js"
 			}
 		},

--- a/dist/funcunit.js
+++ b/dist/funcunit.js
@@ -2,7 +2,7 @@
  * FuncUnit - 2.1-pre
  * http://funcunit.com
  * Copyright (c) 2014 Bitovi
- * Mon, 17 Feb 2014 17:04:02 GMT
+ * Fri, 21 Feb 2014 16:15:52 GMT
  * Licensed MIT */
 
 !function(window) {
@@ -2646,7 +2646,7 @@ var __m2 = (function(Syn) {
 	return Syn;
 })(__m3, __m4, __m5, __m6, __m8);
 
-// ## lib/jquery/jquery.js
+// ## lib/jquery/dist/jquery.js
 var __m11 = (function() {
 /*!
  * jQuery JavaScript Library v1.11.0

--- a/funcunit.html
+++ b/funcunit.html
@@ -8,11 +8,11 @@
 		<div id="qunit"></div>
 		<div id="qunit-fixture"></div>
 		<script src="lib/qunit/qunit/qunit.js"></script>
-		<script src="lib/jquery/jquery.js"></script>
 		<script src="dist/funcunit.js"></script>
 
 		<a id="tester" href="#">Click Me</a>
 		<script type="text/javascript">
+			var $ = FuncUnit.jQuery;
 			$(document).ready(function(){
 				$("#tester").click(function(ev){
 					ev.preventDefault();

--- a/stealconfig.js
+++ b/stealconfig.js
@@ -9,7 +9,7 @@ steal.config({
         }
     },
     paths: {
-        "basejquery": "lib/jquery/jquery.js",
+        "basejquery": "lib/jquery/dist/jquery.js",
         "jquery": "browser/jquery.js",
         "jasmine": "lib/jasmine/lib/jasmine-core/jasmine.js",
         "syn/": "lib/syn/src/"

--- a/test/drag/drag.html
+++ b/test/drag/drag.html
@@ -33,7 +33,7 @@
 			<div id="drop"></div>
 		</div>
 		<div class="status"></div>
-        <script src="../../lib/jquery/jquery.js"></script>
+        <script src="../../lib/jquery/dist/jquery.js"></script>
         <script src="../jquerypp.js"></script>
 		<script src="../../steal/steal.js?funcunit/test/drag"></script>
 	</body>

--- a/test/scroll.html
+++ b/test/scroll.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 		<title>Untitled Document</title>
-   <script src="../lib/jquery/jquery.js" type='text/javascript'></script>
+   <script src="../lib/jquery/dist/jquery.js" type='text/javascript'></script>
    <script type='text/javascript'>
        $(function(){
 				$('#innerdiv').click(function()


### PR DESCRIPTION
jQuery has moved where jquery.js lives from `jquery/jquery.js` to
`jquery/dist/jquery.js`. Because of this many tests were failing. This
updates FuncUnit to use its own internal jQuery and test pages that use
jQuery to use the file in its new location in bower_components.
