### PR TITLE
Correct FuncUnit.win documentation

### DIFF
--- a/browser/open.js
+++ b/browser/open.js
@@ -227,12 +227,12 @@ getAbsolutePath: function( path ) {
 },
 /**
  * @parent utilities
- * @property {window} FuncUnit.win F.win()
+ * @property {window} FuncUnit.win F.win
  * Use this to refer to the window of the application page.
  * @codestart
- *F(F.window).innerWidth(function(w){
+ * F(F.window).innerWidth(function(w){
  *   ok(w > 1000, "window is more than 1000 px wide")
- * })
+ * });
  * @codeend
  */
 win: window,

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "github": "https://github.com/bitovi/funcunit"
   },
   "devDependencies": {
-    "bower": "~1.2.4",
+    "bower": "^1.3.8",
+    "documentjs": "^0.3.0-pre.4",
     "grunt": "0.4.x",
     "grunt-cli": "^0.1.13",
     "grunt-contrib-concat": "0.3.0",


### PR DESCRIPTION
Fixed #117 

Updated bower dep and included documentjs as dev dep

Had to increase the bower version due to the following issue: https://github.com/bower/bower/pull/1403
If documentjs is used to generate the documentation, it should at least be included as a dev dependency just like grunt