### PR TITLE
Check that func.caller exists

### DIFF
--- a/browser/core.js
+++ b/browser/core.js
@@ -10,17 +10,17 @@ var origFuncUnit = FuncUnit;
 FuncUnit = function( selector, frame ) {
   // if you pass true as context, this will avoid doing a synchronous query
   var frame,
-    forceSync, 
+    forceSync,
     isSyncOnly = false;
-  
+
   if(frame && frame.forceSync){
     forceSync = frame.forceSync;
   }
-  
+
   if(frame && typeof frame.frame !== "undefined"){ // its passed as an object
     frame = frame.frame;
   }
-  
+
   isSyncOnly = typeof forceSync === "boolean"? forceSync: isSyncOnly;
 
   assignQunit2Assert(FuncUnit);
@@ -48,7 +48,7 @@ var getContext = function(context){
       var sel = (typeof context === "number" ? "iframe:eq(" + context + ")" : "iframe[name='" + context + "']"),
         frames = new origFuncUnit.fn.init(sel, FuncUnit.win.document.documentElement, true);
       var frame = (frames.length ? frames.get(0).contentWindow : FuncUnit.win).document.documentElement;
-      
+
     } else {
       frame = FuncUnit.win.document.documentElement;
     }
@@ -81,7 +81,7 @@ var getContext = function(context){
   }
 
 var assignQunit2Assert = function (func) {
-	var callerFirstArgument = func.caller.arguments[0];
+	var callerFirstArgument = func.caller && func.caller.arguments[0];
 
 	if(callerFirstArgument && callerFirstArgument.test){
 		FuncUnit.qunit2Assert = callerFirstArgument;


### PR DESCRIPTION
The recent QUnit2 [change](https://github.com/bitovi/funcunit/commit/59bfed3b94af238c9310489bbf68da7dfec4987b#diff-b3352c7d2824192e43631c6a723815fcR83) to the FuncUnit function broke `generator-donejs`, specifically this test:

```js
import F from 'funcunit';
import QUnit from 'steal-qunit';

F.attach(QUnit);

QUnit.module('Extras: routing', {
	beforeEach() {
		F.open('../development.html');
	}
});

QUnit.test('App should route with hashtags', function(assert) {
	F('#goto-dashboard').click(); // <= called here func.caller is null

	F.add(function(){
		assert.equal(F.win.location.hash, '#!/dashboard', 'location.hash should contain a hashtag');
	});
});
```

I cannot really explain how `.caller` is null but it is and since `caller` is deprecated anyway we should be resilient when this hack fails to work, especially for people not using QUnit2.