### PR TITLE
correct how dist is ignored in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ lib
 build
 *.orig
 .DS_Store
-dist
+dist/
 docs/
 guides/
 !doc/guides/


### PR DESCRIPTION
for #232 

### Changes:
Correct how ```dist``` folder is ignored in ```.gitignore``` from just ```dist``` to ```dist/``` so it will be the same as in ```.npmignore```, like this npm will take the configuration of ```.npmignore```