### PR TITLE
Removing the assignment of FuncUnit to the global window object. This…

### DIFF
--- a/global.js
+++ b/global.js
@@ -1,6 +1,9 @@
 require("./funcunit");
 
 var FuncUnit = window.FuncUnit || {};
-window.jQuery = jQuery;
+
+// Removed to avoid stomping on product jQuery in case they're using a different version.
+// For details, see: https://github.com/bitovi/funcunit/issues/236
+//window.jQuery = jQuery; 
 
 module.exports = FuncUnit;


### PR DESCRIPTION
… has been causing a 'FuncUnit is not defined'. The reason why this was not caught in tests is because this occurs in the global.js object, executed as part of the script compilation phase.

Is there any way we can run tests after the compilation phase? Is there a will to do this? Thanks