### PR TITLE
Adding npm debug log to gitignore for funcunit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,29 @@
-testee.log
-npm-debug.log
+
+# Logs
+logs
+*.log
+
+# Dependency directory
+# https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
+site/node_modules/
+
+# Documentation
+docs/
+!doc/guides/
+guides/
+
+# Site
+!site/lib/
+!site/**/lib/
+
+# Misc (move these as appropriate)
+dist/**
+dist/
 lib
 build
 *.orig
 .DS_Store
-dist/
-docs/
-guides/
-!doc/guides/
-site/node_modules/
-!site/lib/
-!site/**/lib/
 .idea/
 static
 index.html

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 testee.log
+npm-debug.log
 node_modules
 lib
 build


### PR DESCRIPTION
The Syn project's gitignore is well organized and fairly exhaustive, with comments detailing the reasons for each category of ignore.

I'd like to update FuncUnit to at least follow the same paradigm, if not be as well organized/documented. This is a first step in that direction, while also ignoring some logs.