### PR TITLE
Updating adapter fake for qunit2

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,7 +3,8 @@ module.exports = {
 		browser: true,
 		node: true,
 		jasmine: true,
-		jquery: true
+		jquery: true,
+		qunit: true
 	},
 	extends: "eslint:recommended",
 	parserOptions: {

--- a/browser/adapters/qunit2.js
+++ b/browser/adapters/qunit2.js
@@ -1,6 +1,5 @@
 module.exports = function (runner) {
 	var doneStack = [];
-	//var _async = QUnit.assert.async; // disallow override; bug or feature? (currently: allowing override)
 	var getCurrentAssert = function () {
 		if (runner.config.current) {
 			return runner.config.current.assert;
@@ -9,7 +8,6 @@ module.exports = function (runner) {
 	}
 	return {
 		pauseTest: function () {
-			//doneStack.push(QUnit.assert.async.call(getCurrentAssert()));
 			doneStack.push(getCurrentAssert().async());
 		},
 		resumeTest: function () {

--- a/browser/adapters/qunit2.js
+++ b/browser/adapters/qunit2.js
@@ -1,6 +1,6 @@
 module.exports = function (runner) {
 	var doneStack = [];
-	var _async = QUnit.assert.async; // disallow override; bug or feature?
+	//var _async = QUnit.assert.async; // disallow override; bug or feature? (currently: allowing override)
 	var getCurrentAssert = function () {
 		if (runner.config.current) {
 			return runner.config.current.assert;
@@ -9,7 +9,8 @@ module.exports = function (runner) {
 	}
 	return {
 		pauseTest: function () {
-			doneStack.push(_async.call(getCurrentAssert()));
+			//doneStack.push(QUnit.assert.async.call(getCurrentAssert()));
+			doneStack.push(getCurrentAssert().async());
 		},
 		resumeTest: function () {
 			doneStack.pop()();

--- a/build.js
+++ b/build.js
@@ -4,7 +4,7 @@ var isNpm = npmUtils.moduleName.isNpm;
 var parseModuleName = npmUtils.moduleName.parse;
 
 stealTools.export({
-	system: {
+	steal: {
 		config: __dirname + "/package.json!npm",
 		"main": "global"
 	},
@@ -32,9 +32,9 @@ stealTools.export({
 		}
 	}
 }).catch(function(e){
-	
+
 	setTimeout(function(){
 		throw e;
 	},1);
-	
+
 });

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "less": "^1.7.0",
     "shelljs": "^0.7.8",
     "steal": "^2.0.0",
+    "steal-css": "^1.0.0",
     "steal-jasmine": "0.0.3",
     "steal-mocha": "0.0.3",
     "steal-qunit": "^1.0.0",
@@ -78,6 +79,9 @@
       "steal",
       "steal-tools",
       "testee"
+    ],
+    "plugins": [
+      "steal-css"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -60,15 +60,15 @@
     "jquerypp": "^2.0.2",
     "less": "^1.7.0",
     "shelljs": "^0.7.8",
-    "steal": "^0.16.35",
+    "steal": "^2.0.0",
     "steal-jasmine": "0.0.3",
     "steal-mocha": "0.0.3",
-    "steal-qunit": "^0.1.1",
-    "steal-qunit2": "1.0.0",
-    "steal-tools": "^0.16.0",
+    "steal-qunit": "^1.0.0",
+    "steal-qunit2": "^2.0.0",
+    "steal-tools": "^2.0.0",
     "testee": "^0.9.1"
   },
-  "system": {
+  "steal": {
     "main": "funcunit",
     "map": {
       "chai": "chai/chai"

--- a/test/adapters/qunit.js
+++ b/test/adapters/qunit.js
@@ -1,11 +1,11 @@
-var QUnit = require("steal-qunit");
+var QUnit = require("steal-qunit2");
 var F = require("funcunit");
 var $ = require("jquery");
 
 F.attach(QUnit);
 
 QUnit.module('Adapters', {
-	setup: function() {
+	beforeEach: function() {
 		$('#qunit-fixture').append('<a class=\'clickme\' href=\'javascript://\'>clickme</a><div class=\'clickresult\'></div>');
 		$('.clickme').click(function() {
 			$('.clickresult').text("clicked");
@@ -13,7 +13,7 @@ QUnit.module('Adapters', {
 	}
 });
 
-test('QUnit adapter test', function() {
+QUnit.test('QUnit adapter test', function() {
 	F.wait(1000);
 	F('.clickme').click();
 	F('.clickresult').text('clicked', 'clicked the link');

--- a/test/adapters/qunit.js
+++ b/test/adapters/qunit.js
@@ -1,11 +1,11 @@
-var QUnit = require("steal-qunit2");
+var QUnit = require("steal-qunit");
 var F = require("funcunit");
 var $ = require("jquery");
 
 F.attach(QUnit);
 
 QUnit.module('Adapters', {
-	beforeEach: function() {
+	setup: function() {
 		$('#qunit-fixture').append('<a class=\'clickme\' href=\'javascript://\'>clickme</a><div class=\'clickresult\'></div>');
 		$('.clickme').click(function() {
 			$('.clickresult').text("clicked");
@@ -13,7 +13,7 @@ QUnit.module('Adapters', {
 	}
 });
 
-QUnit.test('QUnit adapter test', function() {
+test('QUnit adapter test', function() {
 	F.wait(1000);
 	F('.clickme').click();
 	F('.clickresult').text('clicked', 'clicked the link');

--- a/test/adapters/qunit2.js
+++ b/test/adapters/qunit2.js
@@ -23,7 +23,7 @@ QUnit.test("QUnit adapter test", function(assert) {
 
 QUnit.module("QUnit 2 adapter unit tests");
 
-QUnit.test("it works", function(assert) {
+QUnit.test("QUnit2 call count", function(assert) {
 	var adapter = require("../../browser/adapters/qunit2");
 
 	var stats = {
@@ -42,7 +42,9 @@ QUnit.test("it works", function(assert) {
 		},
 		ok: function() {
 			stats.ok += 1;
-		}
+		},
+		test: {}
+		
 	};
 
 	var fakeQunit = {
@@ -51,18 +53,20 @@ QUnit.test("it works", function(assert) {
 		},
 		equiv: function() {
 			stats.equiv += 1;
-		}
+		},
+		config : { current : { assert : fakeAssert }}
 	};
-
+	
 	var adapted = adapter(fakeQunit);
+	debugger;
 
 	fakeQunit.test("test", function() {});
 	adapted.pauseTest();
 	adapted.resumeTest();
-	adapted.assertOK();
+	adapted.assertOK(true);
 	adapted.equiv();
 
-	assert.deepEqual(stats, {
+	QUnit.assert.deepEqual(stats, {
 		async: 1,
 		done: 1,
 		ok: 1,

--- a/test/adapters/qunit2.js
+++ b/test/adapters/qunit2.js
@@ -62,7 +62,7 @@ QUnit.test("QUnit2 call count", function(assert) {
 	fakeQunit.test("test", function() {});
 	adapted.pauseTest();
 	adapted.resumeTest();
-	adapted.assertOK(true);
+	adapted.assertOK();
 	adapted.equiv();
 
 	QUnit.assert.deepEqual(stats, {

--- a/test/adapters/qunit2.js
+++ b/test/adapters/qunit2.js
@@ -58,7 +58,6 @@ QUnit.test("QUnit2 call count", function(assert) {
 	};
 	
 	var adapted = adapter(fakeQunit);
-	debugger;
 
 	fakeQunit.test("test", function() {});
 	adapted.pauseTest();

--- a/test/drag/drag.js
+++ b/test/drag/drag.js
@@ -1,4 +1,4 @@
-steal("../../browser/jquery", "jquerypp/index.js", function($){
+steal("jquerypp/index.js", function($){
 	window.jQuery = $;
 
 	var hoveredOnce = false;


### PR DESCRIPTION
An error in the adapter unit tests occurred because a fake didn't reflect changes to the adapter for QUnit 2 support.

Upon review, Chasen made a few change requests, including one that unblocked this issue.